### PR TITLE
Update arguments regex

### DIFF
--- a/fn-args.js
+++ b/fn-args.js
@@ -8,7 +8,7 @@
 (function () {
 	'use strict';
 
-	var reFnArgs = /\(([^)]+)\)/;
+	var reFnArgs = /^function\s*[^(]*\(([^)]+)\)/;
 
 	var fnArgs = function (fn) {
 		var match = reFnArgs.exec(fn.toString());


### PR DESCRIPTION
Old regex would fail for this:

``` js
fnArgs(function(){console.log('hello')}) --> ['hello']
```
