### PR TITLE
Faster return for function with no arguments

### DIFF
--- a/fn-args.js
+++ b/fn-args.js
@@ -14,6 +14,10 @@
 		if (typeof fn !== 'function') {
 			throw new TypeError('Expected a function');
 		}
+		
+		if (fn.length === 0) {
+			return [];
+		}
 
 		var match = reFnArgs.exec(fn.toString());
 


### PR DESCRIPTION
Just return empty array without converting function to string and regexping over it in such obvious case.
