### PR TITLE
Covered complicated test cases when using comments.

### DIFF
--- a/fn-args.js
+++ b/fn-args.js
@@ -8,6 +8,7 @@
 (function () {
 	'use strict';
 
+	var reComments = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg; // from https://github.com/jrburke/requirejs
 	var reFnArgs = /^function\s*[^(]*\(([^)]+)\)/;
 
 	var fnArgs = function (fn) {
@@ -19,7 +20,7 @@
 			return [];
 		}
 
-		var match = reFnArgs.exec(fn.toString());
+		var match = reFnArgs.exec(fn.toString().replace(reComments, ''));
 
 		return match ? match[1].split(',').map(function (el) {
 			return el.trim();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fn-args",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Get the arguments of a function",
   "license": "MIT",
   "repository": "sindresorhus/fn-args",

--- a/test.js
+++ b/test.js
@@ -4,6 +4,15 @@ var fnArgs = require('./fn-args');
 
 it('should get the arguments of a function', function () {
 	assert.deepEqual(fnArgs(function (foo, bar) {}), ['foo', 'bar']);
+
+	assert.deepEqual(fnArgs(function /* something */may(
+		// go,
+		go,
+		/* wrong, */
+		here
+		// (when, using, comments) {}
+	){}), ['go', 'here']);
+
 	assert.deepEqual(fnArgs(function () {}), []);
 	assert.deepEqual(fnArgs(function(){console.log('hello')}), []);
 });


### PR DESCRIPTION
While user may use comments in any places, you can't be sure about any regexp until you strip them out (check out bundled complicated test case for examples).
