### PR TITLE
Fix trailing comma handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,5 +87,5 @@ module.exports = fn => {
 
 	const match = reFnArgs.exec(fnND);
 
-	return match ? (match[1] || match[2]).split(',').map(x => x.trim()) : [];
+	return match ? (match[1] || match[2]).split(',').map(x => x.trim()).filter(Boolean) : [];
 };

--- a/package.json
+++ b/package.json
@@ -33,12 +33,20 @@
 	],
 	"devDependencies": {
 		"ava": "*",
+		"esm": "3.1.1",
 		"semver": "^5.3.0",
 		"xo": "*"
 	},
 	"xo": {
 		"ignores": [
 			"test*.js"
+		]
+	},
+	"ava": {
+		"babel": false,
+		"compileEnhancements": false,
+		"require": [
+			"esm"
 		]
 	}
 }

--- a/test-newer.js
+++ b/test-newer.js
@@ -7,6 +7,11 @@ test('async function', t => {
 	t.deepEqual(m(async (foo, bar) => {}), ['foo', 'bar']);
 	t.deepEqual(m(async foo => {}), ['foo']);
 
+	t.deepEqual(m(async (
+		trailing,
+		comma,
+	) => {}), ['trailing', 'comma']);
+
 	t.deepEqual(m(async function /* something */may(
 		// go,
 		go,


### PR DESCRIPTION
Fix trailing comma handling by filtering out empty values. Addresses https://github.com/sindresorhus/fn-args/issues/9. ~I need advice on how I can test this with `ava` since it is not reproducible through that tool as explained at https://github.com/sindresorhus/fn-args/issues/9#issuecomment-457293424.~ I figured out how to test. Thanks.